### PR TITLE
Expose main routines as public unsafe

### DIFF
--- a/src/Blake2Fast/Blake2Fast.csproj
+++ b/src/Blake2Fast/Blake2Fast.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<VersionPrefix>2.0.0</VersionPrefix>
+		<VersionPrefix>2.0.1</VersionPrefix>
 		<TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0;net45</TargetFrameworks>
 		<NoWarn>$(NoWarn);NU5104</NoWarn><!-- Release package has prerelease dependency (S.R.I.Experimental) -->
 	</PropertyGroup>

--- a/src/Blake2Fast/Blake2b/Blake2bHashState.cs
+++ b/src/Blake2Fast/Blake2b/Blake2bHashState.cs
@@ -94,13 +94,20 @@ namespace Blake2Fast.Implementation
 			}
 		}
 
-		internal void Init(int digestLength = HashBytes, ReadOnlySpan<byte> key = default)
+		public void Init(int digestLength = HashBytes, ReadOnlySpan<byte> key = default)
 		{
 			uint keylen = (uint)key.Length;
 
 			if (!BitConverter.IsLittleEndian) ThrowHelper.NoBigEndian();
 			if (digestLength == 0 || (uint)digestLength > HashBytes) ThrowHelper.DigestInvalidLength(HashBytes);
 			if (keylen > MaxKeyBytes) ThrowHelper.KeyTooLong(MaxKeyBytes);
+
+			UnsafeInit(digestLength, key);
+		}
+		
+		public void UnsafeInit(int digestLength = HashBytes, ReadOnlySpan<byte> key = default)
+		{
+			uint keylen = (uint)key.Length;
 
 			outlen = (uint)digestLength;
 
@@ -119,6 +126,11 @@ namespace Blake2Fast.Implementation
 			if (outlen == 0) ThrowHelper.HashNotInitialized();
 			if (f[0] != 0) ThrowHelper.HashFinalized();
 
+			UnsafeUpdate(input);
+		}
+		
+		public void UnsafeUpdate(ReadOnlySpan<byte> input)
+		{
 			uint consumed = 0;
 			uint remaining = (uint)input.Length;
 			ref byte rinput = ref MemoryMarshal.GetReference(input);
@@ -195,6 +207,11 @@ namespace Blake2Fast.Implementation
 			if (outlen == 0) ThrowHelper.HashNotInitialized();
 			if (f[0] != 0) ThrowHelper.HashFinalized();
 
+			UnsafeFinish(hash);
+		}
+		
+		public void UnsafeFinish(Span<byte> hash)
+		{
 			if (c < BlockBytes)
 				Unsafe.InitBlockUnaligned(ref b[c], 0, BlockBytes - c);
 


### PR DESCRIPTION
It's convenient to have `Blake2bHashState.Init` method as public.

Also, it would be great to have internal methods, which do the job, public and prefixed with `Unsafe`. E.g.:

* `ComputeAndWriteHash` has `output.Length < digestLength` and `throw` without `ThrowHelper` pattern
* It has 3 methods: `Init, Update, Finish`. `Init` is internal, so it's not possible to skip `ComputeAndWriteHash` call and just manually call the 3 methods.
* `Init` has 3 checks: 
![image](https://user-images.githubusercontent.com/489852/85948412-155b0e80-b951-11ea-9273-5396131b893e.png)
* Update has 1 check in `Update<T>` and two checks in lower-case private `update`.
* `Finish` has one check and two more in lower-case private `finish`, which are the same as in `update`.

Ideally `Blake2bHashState` should expose public `Unsafe` `Init, Update, Finish` method that do no checks at all. The unsafe prefix explicitly tells that it's the caller who is responsible for correct arguments. 

--------------------------------------------------

Some benchmarks:

**CouldHash**

 Case                 |    MOPS |  Elapsed |   GC0 |   GC1 |   GC2 |  Memory 
----------------------|--------:|---------:|------:|------:|------:|--------:
B2Fast Unsafe (MBsec) |  308.62 | 156 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
B2Fast Init (MBsec)   |  284.57 | 169 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
B2Fast CWH (MBsec)    |  267.62 | 179 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
Spreads (MBsec)       |  247.66 | 194 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
Libsodium (MBsec)     |  206.72 | 232 ms |   0.0 |   0.0 |   0.0 | 0.000 MB


**CouldHashIncrementalBench**
*Incremental hashing by 64 bytes 50000 times*

 Case                 |    MOPS |  Elapsed |   GC0 |   GC1 |   GC2 |  Memory 
----------------------|--------:|---------:|------:|------:|------:|--------:
B2Fast Unsafe (MBsec) |  291.40 | 11 ms |   0.0 |   0.0 |   0.0 | 0.004 MB
B2Fast (MBsec)        |  286.55 | 11 ms |   0.0 |   0.0 |   0.0 | 0.007 MB
Spreads (MBsec)       |  284.17 | 11 ms |   0.0 |   0.0 |   0.0 | 0.005 MB


**CouldHashChainedBench**
*Chained hashing by 64 bytes 5000 times*

 Case                 |    MOPS |  Elapsed |   GC0 |   GC1 |   GC2 |  Memory 
----------------------|--------:|---------:|------:|------:|------:|--------:
B2Fast Unsafe (MBsec) |  224.80 | 142 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
B2Fast Init (MBsec)   |  213.12 | 150 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
B2Fast CWH (MBsec)    |  207.61 | 154 ms |   0.0 |   0.0 |   0.0 | 0.000 MB
Spreads (MBsec)       |  192.39 | 166 ms |   0.0 |   0.0 |   0.0 | 0.000 MB


`Spreads` lines are Blake2Fast copied some time ago with API changes similar to what you have added in v.2.0

